### PR TITLE
Minor fixes for next release (originally fixing yarn warning)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,14 +38,15 @@ ARG gateway_branch
 ENV gateway_branch ${branch:-master}
 
 USER node
-RUN cd /home/node && \
+WORKDIR /home/node
+RUN set -x && \
     npm install yarn && \
     mkdir mozilla-iot && \
     cd mozilla-iot && \
     git clone --depth 1 --recursive https://github.com/mozilla-iot/intent-parser && \
     git clone --depth 1 --recursive -b ${gateway_branch} ${gateway_url} && \
     cd gateway && \
-    /home/node/node_modules/.bin/yarn
+    /home/node/node_modules/.bin/yarn --verbose
 
 USER root
 ADD service /etc/service

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,13 +32,18 @@ RUN echo "deb http://ftp.debian.org/debian stretch-backports main" >> /etc/apt/s
     touch /etc/inittab && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
+ARG gateway_url
+ENV gateway_url ${url:-https://github.com/mozilla-iot/gateway}
+ARG gateway_branch
+ENV gateway_branch ${branch:-master}
+
 USER node
 RUN cd /home/node && \
     npm install yarn && \
     mkdir mozilla-iot && \
     cd mozilla-iot && \
-    git clone https://github.com/mozilla-iot/intent-parser && \
-    git clone https://github.com/mozilla-iot/gateway && \
+    git clone --depth 1 --recursive https://github.com/mozilla-iot/intent-parser && \
+    git clone --depth 1 --recursive -b ${gateway_branch} ${gateway_url} && \
     cd gateway && \
     /home/node/node_modules/.bin/yarn
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build: .
     command: /home/node/mozilla-iot/gateway/run-app.sh
     volumes:
-      - /home/node//mozilla-iot/gateway
+      - /home/node/.mozilla-iot
     ports:
       - "8080:8080"
       - "4443:4443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "2"
+
+services:
+  web:
+    build: .
+    command: /home/node/mozilla-iot/gateway/run-app.sh
+    volumes:
+      - /home/node//mozilla-iot/gateway
+    ports:
+      - "8080:8080"
+      - "4443:4443"


### PR DESCRIPTION
yarn failed to install and thus failed to install gateway dependencies,
to we relocate it to let it find gateway's package.json file.

Observed (silent) issue on docker 17.12.1-ce (Ubuntu-18.04) on x86_64:

    npm WARN saveError ENOENT: no such file or directory, open '/home/node/package.json'
    (...)
    + yarn@1.9.4
    added 1 package in 0.447s
    Cloning into 'intent-parser'...
    Cloning into 'gateway'...
    yarn install v1.9.4
    [1/4] Resolving packages...
    [1/4] Resolving packages...
    [2/4] Fetching packages...
    info fsevents@1.2.4: The platform "linux" is incompatible with this module.
    (...)
    [3/4] Linking dependencies...
    [4/4] Building fresh packages...

Change-Id: I8737dfc28da8c8bf266de829725f3c09f62d9468
Signed-off-by: Philippe Coval <p.coval@samsung.com>