### PR TITLE
docker-compose: Remove volume as not needed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,6 @@ services:
   web:
     build: .
     command: /home/node/mozilla-iot/gateway/run-app.sh
-    volumes:
-      - /home/node/.mozilla-iot
     ports:
       - "8080:8080"
       - "4443:4443"


### PR DESCRIPTION
Observed issue was:

    web_1  | mkdir: cannot create directory \
    '/home/node/.mozilla-iot/log': Permission denied

It was verified on node:10-stretch base with:
docker-common-1.10.3-55.gite03ddb8.fc24.armv7hl

Change-Id: Iddc6f8487c80955ce4185cb4f1f9073237e6518e
Signed-off-by: Philippe Coval <p.coval@samsung.com>