### PR TITLE
Worked on starting gateway using docker-compose up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# user profile based files
+config/
+etc/
+log/
+ssl/
+uploads/

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ docker run \
 * `-p 8080:8080` / `-p 4443:4443` - Forward necessary ports to the container
 * `--name mozilla-iot-gateway` - Name of the container
 
+## Using docker-compose
+
+Note: The present docker-compose config file stores the "user profile" data in the same directory where you run the command and it pulls `mozillaiot/gateway:latest`. If you would like to use the ARM version then change the image field to `mozillaiot/gateway:arm`.
+
+``` docker-compose up -d ```
+
 ## Connecting
 
 After running the container, you can connect to it at:

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ docker run \
 
 ## Using docker-compose
 
-Note: The present docker-compose config file stores the "user profile" data in the same directory where you run the command and it pulls `mozillaiot/gateway:latest`. If you would like to use the ARM version then change the image field to `mozillaiot/gateway:arm`.
+***NOTE:*** The present docker-compose config file stores the "user profile" data in the same directory where you run the command, and it pulls `mozillaiot/gateway:latest`. If you would like to use the ARM version, then change the image field to `mozillaiot/gateway:arm`.
 
-``` docker-compose up -d ```
+``` docker-compose up -d```
 
 ## Connecting
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,13 @@
-version: "2"
+version: "3"
 
 services:
   web:
-    build: .
+    container_name: mozilla-iot-gateway
+    image: mozillaiot/gateway:latest
     command: /home/node/mozilla-iot/gateway/run-app.sh
     ports:
       - "8080:8080"
       - "4443:4443"
+    volumes:
+      - /path/to/shared/data:/home/node/.mozilla-iot
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,5 +9,4 @@ services:
       - "8080:8080"
       - "4443:4443"
     volumes:
-      - ./:/home/node/.mozilla-iot
-
+      - .:/home/node/.mozilla-iot

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,5 +9,5 @@ services:
       - "8080:8080"
       - "4443:4443"
     volumes:
-      - /path/to/shared/data:/home/node/.mozilla-iot
+      - ./:/home/node/.mozilla-iot
 


### PR DESCRIPTION
### Context 
Through these changes, 
* we can spin up named docker container. 
* Made user profile data available and persistent in the same directory where we run `docker-compose up`. 
* Made necessary documentation changes. Added **gitignore** file to ignore the user data files.