### PR TITLE
Added and improved port information in Readme and commented in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Compatibility
 
-While the gateway doesn't necessarily require full local network access, some add-ons may. Therefore, it is best to run with the `--net=host` flag. Currently, this flag will not work when using [Docker for Mac](https://docs.docker.com/docker-for-mac/) or [Docker for Windows](https://docs.docker.com/docker-for-windows/) due to [this](https://github.com/docker/for-mac/issues/68) and [this](https://github.com/docker/for-win/issues/543).
+While the gateway doesn't necessarily require full local network access, some add-ons may. Therefore, it is best to run with the `--network="host"` flag. Currently, this flag will not work when using [Docker for Mac](https://docs.docker.com/docker-for-mac/) or [Docker for Windows](https://docs.docker.com/docker-for-windows/) due to [this](https://github.com/docker/for-mac/issues/68) and [this](https://github.com/docker/for-win/issues/543).
 
 ## Usage
 
@@ -17,7 +17,7 @@ While the gateway doesn't necessarily require full local network access, some ad
         -d \
         -e TZ=America/Los_Angeles \
         -v /path/to/shared/data:/home/node/.mozilla-iot \
-        --net=host \
+        --network="host" \
         --name webthings-gateway \
         mozillaiot/gateway:latest
     ```
@@ -44,7 +44,7 @@ docker run \
     -d \
     -e TZ=America/Los_Angeles \
     -v /path/to/shared/data:/home/node/.mozilla-iot \
-    --net=host \
+    --network="host" \
     --name webthings-gateway \
     mozillaiot/gateway:arm
 ```
@@ -54,9 +54,22 @@ docker run \
 * `-d` - Run in daemon mode (in the background)
 * `-e TZ=America/Los_Angeles` - Set the time zone to `America/Los_Angeles`. The list of names can be found [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List).
 * `-v /path/to/shared/data:/home/node/.mozilla-iot` - Change `/path/to/shared/data` to some local path. We are mounting a directory on the host to the container in order to store the persistent "user profile" data, e.g. add-ons, logs, configuration data, etc.
-* `--net=host` - Shares host networking with container (**highly recommended**)
-* `-p 8080:8080` / `-p 4443:4443` - Forward necessary ports to the container
+* `--network="host"` - Shares host networking with container (**highly recommended**, needed by some addons, -p is ignored if this option is used)
+* `-p 8080:8080` / `-p 4443:4443` - Forward necessary ports to the container (ignored if `--network="host"` is present)
 * `--name webthings-gateway` - Name of the container
+
+## Changing ports in `--network="host"` mode
+Create a file `local.json` and map it to `/path/to/shared/data/config/local.json`. Contents of the file:
+
+```json
+{
+  "ports": {
+    "https": 8081,
+    "http": 8080
+  }
+}
+```
+Edit the ports as you like.
 
 ## Using docker-compose
 
@@ -81,7 +94,7 @@ docker run \
     -d \
     -e TZ=America/Los_Angeles \
     -v /path/to/shared/data:/home/node/.mozilla-iot \
-    --net=host \
+    --network="host" \
     --name webthings-gateway \
     gateway
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,10 @@ services:
     image: mozillaiot/gateway:latest
     restart: unless-stopped
     network_mode: host
-    ports:
-      - "8080:8080"
-      - "4443:4443"
+    # ports are ignored because of "network_mode: host". Either use ports or network_mode: host 
+    #ports:
+    #  - "8080:8080"
+    #  - "4443:4443"
     environment:
       - "TZ=America/Los_Angeles"
     volumes:


### PR DESCRIPTION
I've added and improved the port information in the Readme file and commented the ports section of the docker-compose file (reason also added as a comment).
See this issue for the new ports section in the Readme: https://github.com/mozilla-iot/gateway-docker/issues/13

Furthermore I've changed the CLI usage of docker to match their run specification on https://docs.docker.com/engine/reference/run/#network-settings